### PR TITLE
Update UsersController to fix microposts pagination

### DIFF
--- a/.github/workflows/appmap-analysis.yml
+++ b/.github/workflows/appmap-analysis.yml
@@ -40,7 +40,7 @@ jobs:
   appmap-analysis:
     if: always()
     needs: [test]
-    uses: getappmap/analyze-action/.github/workflows/appmap-analysis.yml@v1
+    uses: getappmap/analyze-action/.github/workflows/appmap-analysis.yml@352fbb945abd30c575e69607eff86068dbe19a17
     permissions:
       actions: read
       contents: read

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,7 +10,7 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
-    @microposts = @user.microposts.includes(:user, image_attachment: :blob).paginate(page: params[:page])
+    @microposts = @user.microposts.paginate(page: params[:page])
   end
 
   def new


### PR DESCRIPTION
In the existing code, the show action in the UsersController fetches a user's microposts and eagerly loads associated images using includes(:user, image_attachment: :blob). While this approach ensures that microposts and their associated images are loaded efficiently, it can result in unnecessary database queries and increased loading times when there are a large number of microposts.

We have removed the .includes(:user, image_attachment: :blob) portion when fetching microposts for a user. Instead, we now use @user.microposts.paginate(page: params[:page]) for micropost retrieval. This change eliminates the eager loading of associated images for now.